### PR TITLE
pinephone.conf: add explicit dependency on initramfs-uboot-image

### DIFF
--- a/conf/machine/pinephone.conf
+++ b/conf/machine/pinephone.conf
@@ -45,6 +45,8 @@ IMAGE_BOOT_FILES = " \
     boot.scr \
 "
 
+do_image_wic[depends] += "initramfs-uboot-image:do_image_complete"
+
 PREFERRED_PROVIDER_virtual/kernel = "linux-pinephone"
 KERNEL_IMAGETYPE = "Image"
 KERNEL_DEVICETREE = "allwinner/sun50i-a64-dontbeevil.dtb"


### PR DESCRIPTION
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>