### PR TITLE
linux-pinephone: fix X touchscreen coordinates

### DIFF
--- a/recipes-kernel/linux/linux-pinephone/0001-pinephone-dts-invert-X-coordinates.patch
+++ b/recipes-kernel/linux/linux-pinephone/0001-pinephone-dts-invert-X-coordinates.patch
@@ -1,0 +1,24 @@
+From 23459059c8a12d2e0522d172adb7e4d966122e8f Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sun, 15 Dec 2019 05:19:47 +0000
+Subject: [PATCH] sun50i-a64-pinephone.dts: invert X coordinates
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
+index 0d8bd874915b..c1e55ec88b88 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
+@@ -211,6 +211,7 @@
+ 		AVDD28-supply = <&reg_ldo_io0>;
+ 		touchscreen-size-x = <720>;
+ 		touchscreen-size-y = <1440>;
++		touchscreen-inverted-x;
+ 	};
+ };
+ 
+-- 
+2.17.0
+

--- a/recipes-kernel/linux/linux-pinephone_5.3.bb
+++ b/recipes-kernel/linux/linux-pinephone_5.3.bb
@@ -18,6 +18,7 @@ SRCREV = "6ecddfc2164e0927e75c232d515225c6b21c71b4"
 SRC_URI = " \
           git://gitlab.com/pine64-org/linux.git;protocol=https;branch=${BRANCH} \
 	  file://0001-dts-touchscreen-fix.patch \
+	  file://0001-pinephone-dts-invert-X-coordinates.patch \
           file://defconfig \
           file://extra.cfg \
 	  "


### PR DESCRIPTION
These coordinates get inverted on LuneOS

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>