### PR TITLE
rtl8723cs-module: add Wifi module for pinephone

### DIFF
--- a/conf/machine/pinephone.conf
+++ b/conf/machine/pinephone.conf
@@ -15,7 +15,7 @@ SPL_BINARY ?= "spl/sunxi-spl.bin"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"
 MACHINE_EXTRA_RDEPENDS = " \
-    linux-firmware-rtl8723bs \
+    rtl8723cs-module \
     kernel-modules \
     \
     qtsensors-sensorfw-plugin \

--- a/recipes-kernel/rtl8723cs/rtl8723cs-module_git.bb
+++ b/recipes-kernel/rtl8723cs/rtl8723cs-module_git.bb
@@ -1,0 +1,18 @@
+SECTION = "kernel"
+SUMMARY = "rtl8723cs kernel module for mainline"
+LICENSE = "GPL-2.0"
+LIC_FILES_CHKSUM = "file://core/rtw_ap.c;beginline=5;endline=16;md5=489f99735a5c5aabb3579f49eb06aeb0"
+
+DEPENDS = "virtual/kernel"
+
+inherit module
+
+PV = "1.0.20190730+git${SRCPV}"
+SRCREV = "d7db077004f1497800faabb0e6da775391393711"
+
+SRC_URI = "git://github.com/Icenowy/rtl8723cs.git;branch=master;protocol=git"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE += "KVER=${KERNEL_VERSION} KSRC=${STAGING_KERNEL_DIR} SUBARCH=${@map_kernel_arch(d.getVar('TARGET_ARCH'), d)}"
+
+KERNEL_MODULE_AUTOLOAD += "${MODULE_NAME}"


### PR DESCRIPTION
8723bs was used on the devkit, but the phone uses 8723cs !

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>