### PR TITLE
eg25-manager: fix build race and PV

### DIFF
--- a/recipes-connectivity/eg25-manager/eg25-manager.bb
+++ b/recipes-connectivity/eg25-manager/eg25-manager.bb
@@ -9,13 +9,14 @@ RDEPENDS_${PN} = "atinout"
 inherit meson
 inherit systemd
 
-PV = "0.2.0"
+PV = "0.2.1+git${SRCPV}"
 
 SRCREV = "40136c2a520d3be681aac4201a0e8ef324616140"
 SRC_URI = " \
-    git://gitlab.com/mobian1/devices/eg25-manager;protocol=https;branch=master \
+    git://gitlab.com/mobian1/devices/eg25-manager.git;protocol=https;branch=master \
     file://0001-Fix-udev-dir-for-LuneOS.patch \
     file://0002-Add-VoLTE-configuration.patch \
+    file://0003-src-meson.build-add-dependency-on-gdbofono_src.patch \
     file://eg25-manager.service \
 "
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/eg25-manager/eg25-manager/0003-src-meson.build-add-dependency-on-gdbofono_src.patch
+++ b/recipes-connectivity/eg25-manager/eg25-manager/0003-src-meson.build-add-dependency-on-gdbofono_src.patch
@@ -1,0 +1,49 @@
+From 6b9eb64f62b48fe9df32f1d0d72db70c6cb4ab1d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Fri, 21 May 2021 16:20:27 +0000
+Subject: [PATCH] src/meson.build: add dependency on gdbofono_src
+
+* generated gdbo-manager.h is used by:
+  src/manager.h:#include <libgdbofono/gdbo-manager.h>
+  src/ofono-iface.c:#include <libgdbofono/gdbo-manager.h>
+
+* and without explicit dependency the build sometimes fails with:
+
+FAILED: src/eg25manager.p/ofono-iface.c.o
+aarch64-webos-linux-gcc -Wdate-time --sysroot=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot -Isrc/eg25manager.p -Isrc -I../git/src -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/glib-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/lib/glib-2.0/include -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gio-unix-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libmount -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/blkid -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gudev-1.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libusb-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 '-DEG25_CONFDIR="/etc/eg25-manager"' '-DEG25_DATADIR="/usr/share/eg25-manager"' -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot= -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot-native= -pthread -MD -MQ src/eg25manager.p/ofono-iface.c.o -MF src/eg25manager.p/ofono-iface.c.o.d -o src/eg25manager.p/ofono-iface.c.o -c ../git/src/ofono-iface.c
+In file included from ../git/src/ofono-iface.h:9,
+                 from ../git/src/ofono-iface.c:8:
+../git/src/manager.h:15:10: fatal error: libgdbofono/gdbo-manager.h: No such file or directory
+   15 | #include <libgdbofono/gdbo-manager.h>
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+[2/15] aarch64-webos-linux-gcc -Wdate-time --sysroot=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot -Isrc/eg25manager.p -Isrc -I../git/src -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/glib-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/lib/glib-2.0/include -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gio-unix-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libmount -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/blkid -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gudev-1.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libusb-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 '-DEG25_CONFDIR="/etc/eg25-manager"' '-DEG25_DATADIR="/usr/share/eg25-manager"' -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot= -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot-native= -pthread -MD -MQ src/eg25manager.p/at.c.o -MF src/eg25manager.p/at.c.o.d -o src/eg25manager.p/at.c.o -c ../git/src/at.c
+FAILED: src/eg25manager.p/at.c.o
+aarch64-webos-linux-gcc -Wdate-time --sysroot=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot -Isrc/eg25manager.p -Isrc -I../git/src -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/glib-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/lib/glib-2.0/include -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gio-unix-2.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libmount -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/blkid -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/gudev-1.0 -I/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot/usr/include/libusb-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 '-DEG25_CONFDIR="/etc/eg25-manager"' '-DEG25_DATADIR="/usr/share/eg25-manager"' -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0=/usr/src/debug/eg25-manager/0.2.0-r0 -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot= -fdebug-prefix-map=/home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot-native= -pthread -MD -MQ src/eg25manager.p/at.c.o -MF src/eg25manager.p/at.c.o.d -o src/eg25manager.p/at.c.o -c ../git/src/at.c
+In file included from ../git/src/at.h:9,
+                 from ../git/src/at.c:7:
+../git/src/manager.h:15:10: fatal error: libgdbofono/gdbo-manager.h: No such file or directory
+   15 | #include <libgdbofono/gdbo-manager.h>
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+[3/15] /home/jenkins/workspace/luneos-unstable/webos-ports/tmp-glibc/work/aarch64-webos-linux/eg25-manager/0.2.0-r0/recipe-sysroot-native/usr/bin/gdbus-codegen --c-generate-autocleanup all --interface-prefix org.ofono. --c-namespace GDBO --header --output src/libgdbofono/gdbo-manager.h ../git/src/libgdbofono/manager.xml
+
+Upstream-Status: Submitted [https://gitlab.com/mobian1/devices/eg25-manager/-/merge_requests/20]
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ src/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/meson.build b/src/meson.build
+index f9eb27f..b3e4b27 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -15,6 +15,7 @@ src = [
+         'suspend.c', 'suspend.h',
+         'toml.c', 'toml.h',
+         'udev.c', 'udev.h',
++        gdbofono_src,
+ ]
+ 
+ if mmglib_dep.found()


### PR DESCRIPTION
* current SRCREV is ahead of 0.2.0 tag, adjust PV:

eg25-manager/0.2.0-r0/git$ git log --oneline 0.2.0..40136c2a520d3be681aac4201a0e8ef324616140
40136c2 Allow to build without mmglib
ea19b02 Merge branch 'master' into 'master'
528fe7e Add a 100ms delay before PWRKEY sequence
bd5b5a5 Merge branch 'ofono' into 'master'
ef707c9 Merge branch 'qurccfg_all' into 'master'
2e7a5a6 ofono-iface: add spdx copyright info
52488d2 suspend: if we are using ofono, mark modem as resumed immediately
032bd46 at: if we are using ofono, don't query modem manager for state
060dc9a src: watch ofono service for new modem
dcb1a9a src: add ofono-iface
04eed24 Set URC config to 'all' instead of 'usbat' dquote> When using a custom kernel, if this setting is set to 'usbat' only, no RING urc is reported on any interface. Changing QURCCFG to 'all' makes the modem report RINGs on all supported interfaces, making receiving calls possible when using a custom firmware
3d076e8 (tag: 0.2.1) README: add details about config files
2e7bf44 Merge branch 'at-value-expected-switched' into 'master'
3bf2d78 at: fix argument order
9e40ae1 data: add AT command reporting firmware version

* add .git suffix to URL to avoid redirect:

eg25-manager/0.2.0-r0/git$ git remote update
Fetching origin
warning: redirecting to https://gitlab.com/mobian1/devices/eg25-manager.git/

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>