### PR TITLE
lv_conf.patch: Rebase for 8.1 release

### DIFF
--- a/recipes-graphics/lvgl/lvgl/lv_conf.patch
+++ b/recipes-graphics/lvgl/lvgl/lv_conf.patch
@@ -1,5 +1,19 @@
---- a/lv_conf_template.h	2022-05-11 18:40:15.637267548 +0000
-+++ b/lv_conf_template.h	2022-05-11 18:50:39.901987219 +0000
+From d7b2f80fa0fa844c9b7ca2edb46d3eefc52176b2 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Mon, 27 Jun 2022 17:47:52 +0200
+Subject: [PATCH] lv_conf_template.h: Patch for LuneOS
+
+Based on https://github.com/webOS-ports/meta-pine64-luneos/pull/33/files#diff-1f83379de8ac9529daeebceec39536c3f77ba2fbb35cae98447941cfd6794232
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ lv_conf_template.h | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/lv_conf_template.h b/lv_conf_template.h
+index 8bdddb49..0d8ae799 100644
+--- a/lv_conf_template.h
++++ b/lv_conf_template.h
 @@ -12,7 +12,7 @@
   */
  
@@ -13,62 +27,63 @@
   *====================*/
  
  /*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
--#define LV_COLOR_DEPTH     16
-+#define LV_COLOR_DEPTH     32
+-#define LV_COLOR_DEPTH 16
++#define LV_COLOR_DEPTH 32
  
  /*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
- #define LV_COLOR_16_SWAP   0
-@@ -45,7 +45,7 @@
- #define LV_MEM_CUSTOM      0
+ #define LV_COLOR_16_SWAP 0
+@@ -49,7 +49,7 @@
+ #define LV_MEM_CUSTOM 0
  #if LV_MEM_CUSTOM == 0
  /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
--#  define LV_MEM_SIZE    (32U * 1024U)          /*[bytes]*/
+-#  define LV_MEM_SIZE (32U * 1024U)          /*[bytes]*/
 +#  define LV_MEM_SIZE    (1024U * 1024U)          /*[bytes]*/
  
  /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
- #  define LV_MEM_ADR          0     /*0: unused*/
-@@ -173,7 +173,7 @@
+ #  define LV_MEM_ADR 0     /*0: unused*/
+@@ -171,7 +171,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
   *-----------*/
  
  /*Enable the log module*/
--#define LV_USE_LOG      0
+-#define LV_USE_LOG 0
 +#define LV_USE_LOG      1
  #if LV_USE_LOG
  
  /*How important log should be added:
-@@ -183,11 +183,11 @@
+@@ -181,11 +181,11 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
   *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
   *LV_LOG_LEVEL_USER        Only logs added by the user
   *LV_LOG_LEVEL_NONE        Do not log anything*/
--#  define LV_LOG_LEVEL    LV_LOG_LEVEL_WARN
+-#  define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
 +#  define LV_LOG_LEVEL    LV_LOG_LEVEL_INFO
  
  /*1: Print the log with 'printf';
   *0: User need to register a callback with `lv_log_register_print_cb()`*/
--#  define LV_LOG_PRINTF   0
-+#  define LV_LOG_PRINTF   1
+-#  define LV_LOG_PRINTF 0
++#  define LV_LOG_PRINTF 1
  
  /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
- #  define LV_LOG_TRACE_MEM            1
-@@ -347,10 +347,10 @@
- #define LV_FONT_FMT_TXT_LARGE   0
+ #  define LV_LOG_TRACE_MEM        1
+@@ -348,10 +348,10 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+ #define LV_FONT_FMT_TXT_LARGE 0
  
  /*Enables/disables support for compressed fonts.*/
--#define LV_USE_FONT_COMPRESSED  0
-+#define LV_USE_FONT_COMPRESSED  1
+-#define LV_USE_FONT_COMPRESSED 0
++#define LV_USE_FONT_COMPRESSED 1
  
  /*Enable subpixel rendering*/
--#define LV_USE_FONT_SUBPX       0
-+#define LV_USE_FONT_SUBPX       1
+-#define LV_USE_FONT_SUBPX 0
++#define LV_USE_FONT_SUBPX 1
  #if LV_USE_FONT_SUBPX
  /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
- #define LV_FONT_SUBPX_BGR       0  /*0: RGB; 1:BGR order*/
-@@ -512,7 +512,7 @@
+ #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+@@ -513,7 +513,7 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
  #if LV_USE_THEME_DEFAULT
  
  /*0: Light mode; 1: Dark mode*/
--# define LV_THEME_DEFAULT_DARK     0
-+# define LV_THEME_DEFAULT_DARK     1
+-# define LV_THEME_DEFAULT_DARK 0
++# define LV_THEME_DEFAULT_DARK 1
  
  /*1: Enable grow on press*/
- # define LV_THEME_DEFAULT_GROW              1
+ # define LV_THEME_DEFAULT_GROW 1
+-- 


### PR DESCRIPTION
Seems Kirkstone uses 8.1 release so patch fails.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>