### PR TITLE
sensorfw: Split to keep layers clean

### DIFF
--- a/recipes-support/sensorfw/sensorfw.bbappend
+++ b/recipes-support/sensorfw/sensorfw.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+# Configuration files for the sensors on Pine64 devices
+SRC_URI:append:pinephone = " \
+    file://sensord-pinephone.conf \
+"
+SRC_URI:append:pinephonepro = " \
+    file://sensord-pinephonepro.conf \
+"
+
+SRC_URI:append:pinetab2 = " \
+    file://sensord-pinetab2.conf \
+"

--- a/recipes-support/sensorfw/sensorfw/sensord-pinephone.conf
+++ b/recipes-support/sensorfw/sensorfw/sensord-pinephone.conf
@@ -1,0 +1,23 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+
+[accelerometer]
+input_match=mpu6050
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,1,0,-1,0,0,0,0,1"
+
+[als]
+input_match=stk3310
+intervals = "200=>2000"
+default_interval=500
+
+[gyroscope]
+input_match=mpu6050
+
+[magnetometer]
+input_match=lis3mdl

--- a/recipes-support/sensorfw/sensorfw/sensord-pinephonepro.conf
+++ b/recipes-support/sensorfw/sensorfw/sensord-pinephonepro.conf
@@ -1,0 +1,23 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+
+[accelerometer]
+input_match=ak8975
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,1,0,-1,0,0,0,0,1"
+
+[als]
+input_match=stk3310
+intervals = "200=>2000"
+default_interval=500
+
+[gyroscope]
+input_match=ak8975
+
+[magnetometer]
+input_match=lis3mdl

--- a/recipes-support/sensorfw/sensorfw/sensord-pinetab2.conf
+++ b/recipes-support/sensorfw/sensorfw/sensord-pinetab2.conf
@@ -1,0 +1,23 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+
+[accelerometer]
+input_match=ak8975
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,1,0,-1,0,0,0,0,1"
+
+[als]
+input_match=stk3310
+intervals = "200=>2000"
+default_interval=500
+
+[gyroscope]
+input_match=ak8975
+
+[magnetometer]
+input_match=lis3mdl


### PR DESCRIPTION
Add a bbappend for Pine64 devices instead of polluting the main sensorfw recipe.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>