### PR TITLE
luneos-recovery-ui, lv-lib-png: use MACHINE_ARCH because lvgl does

### DIFF
--- a/recipes-graphics/lvgl/lv-lib-png_%.bbappend
+++ b/recipes-graphics/lvgl/lv-lib-png_%.bbappend
@@ -1,0 +1,2 @@
+# Because meta-pine64-luneos/recipes-graphics/lvgl/lvgl_%.bbappend makes lvgl MACHINE_ARCH as well
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-luneui/recovery/luneos-recovery-ui.bb
+++ b/recipes-luneui/recovery/luneos-recovery-ui.bb
@@ -15,3 +15,6 @@ inherit cmake
 
 TARGET_CFLAGS += "-DLV_CONF_INCLUDE_SIMPLE=1"
 TARGET_CFLAGS += "-I${RECIPE_SYSROOT}/${includedir}/lvgl -I${RECIPE_SYSROOT}/${includedir}/lvgl/lv_drivers"
+
+# Because meta-pine64-luneos/recipes-graphics/lvgl/lvgl_%.bbappend makes lvgl MACHINE_ARCH as well
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
* meta-pine64-luneos/recipes-graphics/lvgl/lvgl_%.bbappend makes lvgl MACHINE_ARCH