### PR TITLE
meta-pine64-luneos: Add loading of PT2 wifi module

### DIFF
--- a/recipes-core/systemd/systemd-machine-units/pinetab2/wifi-module-load.service
+++ b/recipes-core/systemd/systemd-machine-units/pinetab2/wifi-module-load.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load wifi module
+DefaultDependencies=false
+Conflicts=shutdown.target
+After=dbus.service
+
+[Service]
+Type=simple
+RemainAfterExit=yes
+ExecStart=/sbin/modprobe mac80211
+ExecStartPost=/bin/sleep 2
+ExecStartPost=modprobe bes2600
+ExecStartPost=/bin/sleep 4
+ExecStartPost=/usr/sbin/rfkill unblock wifi
+ExecStop=/sbin/modprobe -r bes2600
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=basic.target

--- a/recipes-core/systemd/systemd-machine-units_1.0.bbappend
+++ b/recipes-core/systemd/systemd-machine-units_1.0.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:pinetab2 = " \
+    file://wifi-module-load.service \
+"
+
+do_install:append:pinetab2() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/wifi-module-load.service ${D}${systemd_unitdir}/system
+}
+
+SYSTEMD_SERVICE:${PN}:pinetab2 = " \
+    wifi-module-load.service \
+"


### PR DESCRIPTION
Similar to what we do in meta-smartphone for most of our Android based targets.